### PR TITLE
回复“CRF分词的纯Java实现”

### DIFF
--- a/src/main/java/com/hankcs/hanlp/HanLP.java
+++ b/src/main/java/com/hankcs/hanlp/HanLP.java
@@ -372,10 +372,62 @@ public class HanLP
      * 与直接new一个分词器相比，使用本方法的好处是，以后HanLP升级了，总能用上最合适的分词器
      * @return 一个分词器
      */
-    public static Segment newSegment()
+    /*public static Segment newSegment()
     {
         return new ViterbiSegment();   // Viterbi分词器是目前效率和效果的最佳平衡
-    }
+    }*/
+    
+    
+    public static Segment newSegment() {
+		return segmentLocal.get();// 以Viterbi分词器做为默认分词工具，同时支持用户选择其他分词器
+	}
+    public static final byte CRF_SEGMENT = 0;
+	public static final byte HMM_SEGMENT = 1;
+	public static final byte AHO_CORASICK_DOUBLE_ARRAY_TRIE_SEGMENT = 2;
+	public static final byte DOUBLE_ARRAY_TRIE_SEGMENT = 3;
+	public static final byte DIJKSTRA_SEGMENT = 4;
+	public static final byte N_SHORT_SEGMENT = 5;
+	public static final byte VITERBI_SEGMENT = 6;
+	public static ThreadLocal<Segment> segmentLocal = new ThreadLocal<Segment>(){
+		protected Segment initialValue() {
+	        return new ViterbiSegment();
+	    }
+	};
+	public static Segment setSegment(Segment segment){
+		segmentLocal.set(segment);
+		return segment;
+	}
+	public static Segment setSegment(byte segment){
+		Segment segmentObj;
+		switch(segment){
+			case 0:
+				segmentObj = new CRFSegment();
+				break;
+			case 1:
+				segmentObj = new HMMSegment();
+				break;
+			case 2:
+				segmentObj = new AhoCorasickDoubleArrayTrieSegment();
+				break;
+			case 3:
+				segmentObj = new DoubleArrayTrieSegment();
+				break;
+			case 4:
+				segmentObj = new DijkstraSegment();
+				break;
+			case 5:
+				segmentObj = new NShortSegment();
+				break;
+			case 6:
+				segmentObj = new ViterbiSegment();
+				break;
+			default:
+				segmentObj = new ViterbiSegment();
+		}
+		return setSegment(segmentObj);
+	}
+
+    
 
     /**
      * 依存文法分析


### PR DESCRIPTION
URL:http://www.hankcs.com/nlp/segment/crf-segmentation-of-the-pure-java-implementation.html

可能是我现在对HanLP的了解还太片面。请让我先说明下为什么会觉得有些不妥当。
在看这篇文章前，先看了《HanLP开源》，中间有提到
“HanLP几乎所有的功能都可以通过工具类HanLP快捷调用，当你想不起来调用方法时，只需键入HanLP.，IDE应当会给出提示，并展示HanLP完善的文档。
推荐用户始终通过工具类HanLP调用，这么做的好处是，将来HanLP升级后，用户无需修改调用代码。”
于是，在尝试测试本文的“你看过穆赫兰道吗”时，也试着用HanLP调用，但结果与你展示结果不同，查看源码发现HanLP默认使用的是ViterbiSegment对象，但又没有可以设置我需要的segment的地方，因此觉得现有代码并没有像你说的那样，能够几乎所有的功能都能被HanLP调用。

看过你的回复，知道了newSegment()的作用，也初步了解你要这么做的原因:避免产生线程不安全的问题，因此你使用了一个静态方法返回一个新对象的方式实现。另外你提到的“那么就得考虑用户的代码的副作用，他会不会把text的charArray改动了”我不是太明白。

为了达到至少我认为的“HanLP几乎所有的功能都可以通过工具类HanLP快捷调用”，我复制了你提供的HanLP源码，并做了一些改动：
	添加了如下代码：		
	public static final byte CRF_SEGMENT = 0;
	public static final byte HMM_SEGMENT = 1;
	public static final byte AHO_CORASICK_DOUBLE_ARRAY_TRIE_SEGMENT = 2;
	public static final byte DOUBLE_ARRAY_TRIE_SEGMENT = 3;
	public static final byte DIJKSTRA_SEGMENT = 4;
	public static final byte N_SHORT_SEGMENT = 5;
	public static final byte VITERBI_SEGMENT = 6;
	public static ThreadLocal<Segment> segmentLocal = new ThreadLocal<Segment>(){
		protected Segment initialValue() {
	        return new ViterbiSegment();
	    }
	};
	public static Segment setSegment(Segment segment){
		segmentLocal.set(segment);
		return segment;
	}
	public static Segment setSegment(byte segment){
		Segment segmentObj;
		switch(segment){
			case 0:
				segmentObj = new CRFSegment();
				break;
			case 1:
				segmentObj = new HMMSegment();
				break;
			case 2:
				segmentObj = new AhoCorasickDoubleArrayTrieSegment();
				break;
			case 3:
				segmentObj = new DoubleArrayTrieSegment();
				break;
			case 4:
				segmentObj = new DijkstraSegment();
				break;
			case 5:
				segmentObj = new NShortSegment();
				break;
			case 6:
				segmentObj = new ViterbiSegment();
				break;
			default:
				segmentObj = new ViterbiSegment();
		}
		return setSegment(segmentObj);
	}

改方法newSegment()为：
	public static Segment newSegment() {
		return segmentLocal.get();// 以Viterbi分词器做为默认分词工具，同时支持用户选择其他分词器
	}

除此之外，其他类都不需要改动。我想，ThreadLocal的运行机制能保证变量在单个线程内部共享但线程间不共享，除了减少内存占用外，不会产生线程不安全的问题，亦不会有资源争用的问题，还能向用户提供自己定义需要的segment的功能。


如下是两种实现“你看过穆赫兰道吗”的方式，(当然，看起来差不多)：
		CRFSegment segment = new CRFSegment();
		segment.enablePartOfSpeechTagging(true);
		System.out.println("previous version:\t"+segment.seg("你看过穆赫兰道吗"));
		
		NewHanLP.Config.enableDebug(true);
		NewHanLP.setSegment(NewHanLP.CRF_SEGMENT).enablePartOfSpeechTagging(true);
		System.out.println("new version:\t\t"+NewHanLP.segment("你看过穆赫兰道吗"));


输出：
previous version:		[你/rr, 看过/v, 穆赫兰道/null, 吗/y]
new version:		[你/rr, 看过/v, 穆赫兰道/null, 吗/y]

欢迎拍砖 :)