### PR TITLE
fix:繁体分词bug

### DIFF
--- a/src/main/java/com/hankcs/hanlp/tokenizer/TraditionalChineseTokenizer.java
+++ b/src/main/java/com/hankcs/hanlp/tokenizer/TraditionalChineseTokenizer.java
@@ -49,24 +49,26 @@ public class TraditionalChineseTokenizer
         }
         String simplifiedChinese = sbSimplifiedChinese.toString();
         List<Term> termList = SEGMENT.seg(simplifiedChinese);
-        Iterator<Term> termIterator = termList.iterator();
-        Iterator<ResultTerm<String>> tsIterator = tsList.iterator();
-        ResultTerm<String> tsTerm = tsIterator.next();
-        int offset = 0;
-        while (termIterator.hasNext())
-        {
-            Term term = termIterator.next();
-            term.offset = offset;
-            if (offset > tsTerm.offset) tsTerm = tsIterator.next();
-
-            if (offset == tsTerm.offset && term.length() == tsTerm.label.length())
-            {
-                term.word = tsTerm.word;
-            }
-            else term.word = SimplifiedChineseDictionary.convertToTraditionalChinese(term.word);
-            offset += term.length();
+        if (tsList.size() == 1) {
+            if (termList.size() == 1)
+                termList.get(0).word = SimplifiedChineseDictionary.convertToTraditionalChinese(termList.get(0).word);
         }
+        else {
+            Iterator<Term> termIterator = termList.iterator();
+            Iterator<ResultTerm<String>> tsIterator = tsList.iterator();
+            ResultTerm<String> tsTerm = tsIterator.next();
+            int offset = 0;
+            while (termIterator.hasNext()) {
+                Term term = termIterator.next();
+                term.offset = offset;
+                if (offset > tsTerm.offset) tsTerm = tsIterator.next();
 
+                if (offset == tsTerm.offset && term.length() == tsTerm.label.length()) {
+                    term.word = tsTerm.word;
+                } else term.word = SimplifiedChineseDictionary.convertToTraditionalChinese(term.word);
+                offset += term.length();
+            }
+        }
         return termList;
     }
 


### PR DESCRIPTION
版本:208e338600be8ac219b9112a1163aaeef2df2b8a
```
 TraditionalChineseTokenizer.segment("认可程度");
```
繁体分词，输入全为简体时分导致程序异常出错。
原因是简体输入在繁简转换时生成的term列表数量和后面简体分词时生成的term数量不一致。