### PR TITLE
微调机构名识别模型

### DIFF
--- a/src/test/java/com/hankcs/demo/DemoNShortSegment.java
+++ b/src/test/java/com/hankcs/demo/DemoNShortSegment.java
@@ -29,6 +29,7 @@ public class DemoNShortSegment
         String[] testCase = new String[]{
                 "今天，刘志军案的关键人物,山西女商人丁书苗在市二中院出庭受审。",
                 "江西省监狱管理局与中国太平洋财产保险股份有限公司南昌中心支公司保险合同纠纷案",
+                "新北商贸有限公司",
         };
         for (String sentence : testCase)
         {


### PR DESCRIPTION
新开头的一些机构的名称，“新”误被识别为“A”，成为机构的前缀词