### PR TITLE
SetPropertiesFilePath

### DIFF
--- a/src/main/java/com/hankcs/hanlp/HanLP.java
+++ b/src/main/java/com/hankcs/hanlp/HanLP.java
@@ -27,6 +27,7 @@ import com.hankcs.hanlp.summary.TextRankSentence;
 import com.hankcs.hanlp.tokenizer.StandardTokenizer;
 
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.InputStreamReader;
 import java.util.List;
 import java.util.Properties;
@@ -43,11 +44,21 @@ import static com.hankcs.hanlp.utility.Predefine.logger;
  */
 public class HanLP
 {
+	public static String PropertiesFilePath;
+    /**
+     * 指定properties文件位置
+     */
+    public static void SetPropertiesFile(String sPath)
+    {
+    	PropertiesFilePath = sPath;
+    }
+    
     /**
      * 库的全局配置，既可以用代码修改，也可以通过hanlp.properties配置（按照 变量名=值 的形式）
      */
     public static final class Config
     {
+    	
         /**
          * 开发模式
          */
@@ -175,7 +186,15 @@ public class HanLP
             Properties p = new Properties();
             try
             {
-                p.load(new InputStreamReader(Thread.currentThread().getContextClassLoader().getResourceAsStream("hanlp.properties"), "UTF-8"));
+            	if( HanLP.PropertiesFilePath != null)
+            	{
+            		File file = new File( HanLP.PropertiesFilePath );  
+            		FileInputStream fIn = new FileInputStream(file);  
+            		InputStreamReader isr = new InputStreamReader(fIn);  
+            		p.load( isr );
+            	} else {
+            		p.load(new InputStreamReader(Thread.currentThread().getContextClassLoader().getResourceAsStream("hanlp.properties"), "UTF-8"));
+            	}
                 String root = p.getProperty("root", "").replaceAll("\\\\", "/");
                 if (!root.endsWith("/")) root += "/";
                 CoreDictionaryPath = root + p.getProperty("CoreDictionaryPath", CoreDictionaryPath);
@@ -256,6 +275,8 @@ public class HanLP
         {
             enableDebug(true);
         }
+        
+        
 
         /**
          * 开启调试模式(会降低性能)

--- a/src/main/java/com/hankcs/hanlp/HanLP.java
+++ b/src/main/java/com/hankcs/hanlp/HanLP.java
@@ -190,7 +190,7 @@ public class HanLP
             	{
             		File file = new File( HanLP.PropertiesFilePath );  
             		FileInputStream fIn = new FileInputStream(file);  
-            		InputStreamReader isr = new InputStreamReader(fIn);  
+            		InputStreamReader isr = new InputStreamReader(fIn, "UTF-8");  
             		p.load( isr );
             	} else {
             		p.load(new InputStreamReader(Thread.currentThread().getContextClassLoader().getResourceAsStream("hanlp.properties"), "UTF-8"));


### PR DESCRIPTION
添加指定PropertiesFile文件路径的方法。
--------
由于IKVM转换的DLL文件暂无法支持java的getContextClassLoader().getResourceAsStream方法。出此下策，直接指定properties文件位置。添加此功能后，IKVM转换后的DLL文件可被.net程序直接使用。我试验了多种分词方法和文档摘要方法，均可执行。
