### PR TITLE
使用 File.getCanonicalPath() to 展开 hanlp.properties 里指定的 root 

### DIFF
--- a/src/main/java/com/hankcs/hanlp/HanLP.java
+++ b/src/main/java/com/hankcs/hanlp/HanLP.java
@@ -186,7 +186,10 @@ public class HanLP
                         loader.getResourceAsStream("hanlp.properties") :
                         new FileInputStream(Predefine.HANLP_PROPERTIES_PATH)
                         , "UTF-8"));
-                String root = p.getProperty("root", "").replaceAll("\\\\", "/");
+
+                File rootPathFromProperties = new File(p.getProperty("root", "").replaceAll("\\\\", "/"));
+                String root = rootPathFromProperties.getCanonicalPath();
+
                 if (!root.endsWith("/")) root += "/";
                 CoreDictionaryPath = root + p.getProperty("CoreDictionaryPath", CoreDictionaryPath);
                 CoreDictionaryTransformMatrixDictionaryPath = root + p.getProperty("CoreDictionaryTransformMatrixDictionaryPath", CoreDictionaryTransformMatrixDictionaryPath);
@@ -440,7 +443,7 @@ public class HanLP
     {
         return TextRankSentence.getTopSentenceList(document, size);
     }
-    
+
     /**
      * 自动摘要
      * @param document 目标文档


### PR DESCRIPTION
使用 `File.getCanonicalPath()` to 展开` hanlp.properties` 里指定的 root，这样可以在 `hanlp.properties` 里使用类似 `.` / `..` 等相对路径的表达