### PR TITLE
Fix bug on println(CoNLLWord)

### DIFF
--- a/src/main/java/com/hankcs/hanlp/corpus/dependency/CoNll/CoNLLWord.java
+++ b/src/main/java/com/hankcs/hanlp/corpus/dependency/CoNll/CoNLLWord.java
@@ -110,9 +110,15 @@ public class CoNLLWord
     public String toString()
     {
         final StringBuilder sb = new StringBuilder();
-        sb.append(ID).append('\t').append(LEMMA).append('\t').append(LEMMA).append('\t').append(CPOSTAG).append('\t')
+        if (HEAD.ID!=0 && HEAD.ID!=-1){
+            sb.append(ID).append('\t').append(LEMMA).append('\t').append(LEMMA).append('\t').append(CPOSTAG).append('\t')
                 .append(POSTAG).append('\t').append('_').append('\t').append(HEAD.ID).append('\t').append(DEPREL).append('\t')
-                .append('_').append('\t').append('_');
+                .append('_').append('\t').append('_');  
+        } else {
+            sb.append(ID).append('\t').append(LEMMA).append('\t').append(LEMMA).append('\t').append(CPOSTAG).append('\t')
+                .append(POSTAG).append('\t').append('_').append('\t').append('_').append('\t').append(DEPREL).append('\t')
+                .append('_').append('\t').append('_');  
+        }
         return sb.toString();
     }
 }

--- a/src/main/java/com/hankcs/hanlp/corpus/dependency/CoNll/CoNLLWord.java
+++ b/src/main/java/com/hankcs/hanlp/corpus/dependency/CoNll/CoNLLWord.java
@@ -110,7 +110,8 @@ public class CoNLLWord
     public String toString()
     {
         final StringBuilder sb = new StringBuilder();
-        if (HEAD.ID!=0 && HEAD.ID!=-1){
+        // ID为0时为根节点，ID为-1时为空白节点
+        if (ID!=0 && ID!=-1){
             sb.append(ID).append('\t').append(LEMMA).append('\t').append(LEMMA).append('\t').append(CPOSTAG).append('\t')
                 .append(POSTAG).append('\t').append('_').append('\t').append(HEAD.ID).append('\t').append(DEPREL).append('\t')
                 .append('_').append('\t').append('_');  


### PR DESCRIPTION
这次修改没有引入第三方类库
没有修改JDK版本号
所有文本都是UTF-8编码
代码风格一致
[x ] 我在此括号内输入x打钩，代表上述事项确认完毕

当分析依存关系时，需要考虑每个CoNLLWord的依存弧指向的CoNLLWord。当该CoNLLWord本身为root时，输出该片段的HEAD会
报错。

报错代码段如下：
CoNLLSentence sentence = HanLP.parseDependency("坚决惩治贪污贿赂等经济犯罪");
for (CoNLLWord word : sentence) {
System.out.println(word.HEAD);
}

分析原因为：
root的初始化代码为
public static final CoNLLWord ROOT = new CoNLLWord(0, "##核心##", "ROOT",
"root");
其HEAD值为空，在toString方法中调用HEAD.ID时报错。

修改方法为：
在CoNLLWord的toString方法中判断是否为根节点(root)或空白节点(null)，若是则将HEAD.ID替换为下划线。