### PR TITLE
修正全角年份识别中字符串长度错误

### DIFF
--- a/src/main/java/com/hankcs/hanlp/utility/TextUtility.java
+++ b/src/main/java/com/hankcs/hanlp/utility/TextUtility.java
@@ -414,7 +414,7 @@ public class TextUtility
             if (isAllSingleByte(snum)
                     && (len == 4 || len == 2 && (cint(first) > 4 || cint(first) == 0)))
                 return true;
-            if (isAllNum(snum) && (len >= 6 || len == 4 && "０５６７８９".indexOf(first) != -1))
+            if (isAllNum(snum) && (len >= 3 || len == 2 && "０５６７８９".indexOf(first) != -1))
                 return true;
             if (getCharCount("零○一二三四五六七八九壹贰叁肆伍陆柒捌玖", snum) == len && len >= 2)
                 return true;


### PR DESCRIPTION
<!--
感谢你对开源事业的贡献！这是一份模板，方便记录你做出的功绩，谢谢！
-->

## 注意事项

* 这次修改没有引入第三方类库。
* 也没有修改JDK版本号
* 所有文本都是UTF-8编码
* 代码风格一致
* [x ] 我在此括号内输入x打钩，代表上述事项确认完毕。

## 解决了什么问题？带来了什么好处？

在MSR语料的分词测试中发现。年份判断中有一处错误，导致不能识别全角字符年份，

## 相关issue

（无）