### PR TITLE
增加两个新的文本摘要抽取方法，在抽取文本摘要时指定句子分割符，改变默认的句子分割符

### DIFF
--- a/src/main/java/com/hankcs/hanlp/HanLP.java
+++ b/src/main/java/com/hankcs/hanlp/HanLP.java
@@ -594,6 +594,7 @@ public class HanLP
 
     /**
      * 自动摘要
+     * 分割目标文档时的默认句子分割符为，,。:：“”？?！!；;
      * @param document 目标文档
      * @param size 需要的关键句的个数
      * @return 关键句列表
@@ -605,6 +606,7 @@ public class HanLP
 
     /**
      * 自动摘要
+     * 分割目标文档时的默认句子分割符为，,。:：“”？?！!；;
      * @param document 目标文档
      * @param max_length 需要摘要的长度
      * @return 摘要文本
@@ -615,4 +617,31 @@ public class HanLP
         // The actual length of the summary generated may be short than the required length, but never longer;
         return TextRankSentence.getSummary(document, max_length);
     }
+
+    /**
+     * 自动摘要
+     * @param document 目标文档
+     * @param size 需要的关键句的个数
+     * @param sentence_separator 分割目标文档时的句子分割符，正则格式， 如：[。？?！!；;]
+     * @return 关键句列表
+     */
+    public static List<String> extractSummary(String document, int size, String sentence_separator)
+    {
+        return TextRankSentence.getTopSentenceList(document, size, sentence_separator);
+    }
+
+    /**
+     * 自动摘要
+     * @param document 目标文档
+     * @param max_length 需要摘要的长度
+     * @param sentence_separator 分割目标文档时的句子分割符，正则格式， 如：[。？?！!；;]
+     * @return 摘要文本
+     */
+    public static String getSummary(String document, int max_length, String sentence_separator)
+    {
+        // Parameter size in this method refers to the string length of the summary required;
+        // The actual length of the summary generated may be short than the required length, but never longer;
+        return TextRankSentence.getSummary(document, max_length, sentence_separator);
+    }
+    
 }

--- a/src/main/java/com/hankcs/hanlp/summary/TextRankSentence.java
+++ b/src/main/java/com/hankcs/hanlp/summary/TextRankSentence.java
@@ -35,6 +35,8 @@ public class TextRankSentence
      */
     final static int max_iter = 200;
     final static double min_diff = 0.001;
+    
+    final static String default_sentence_separator = "[，,。:：“”？?！!；;]";
     /**
      * 文档句子的个数
      */
@@ -155,18 +157,31 @@ public class TextRankSentence
 
     /**
      * 将文章分割为句子
+     * 默认句子分隔符为：[，,。:：“”？?！!；;]
      *
      * @param document
      * @return
      */
-    static List<String> spiltSentence(String document)
+    static List<String> splitSentence(String document)
+    {
+    	return splitSentence(document, default_sentence_separator);
+    }
+
+    /**
+     * 将文章分割为句子
+     *	 
+     * @param document 待分割的文档
+     * @param sentence_separator 句子分隔符，正则表达式，如：   [。:？?！!；;]
+     * @return
+     */
+    static List<String> splitSentence(String document, String sentence_separator)
     {
         List<String> sentences = new ArrayList<String>();
         for (String line : document.split("[\r\n]"))
         {
             line = line.trim();
             if (line.length() == 0) continue;
-            for (String sent : line.split("[，,。:：“”？?！!；;]"))
+            for (String sent : line.split(sentence_separator))		// [，,。:：“”？?！!；;]
             {
                 sent = sent.trim();
                 if (sent.length() == 0) continue;
@@ -211,7 +226,20 @@ public class TextRankSentence
      */
     public static List<String> getTopSentenceList(String document, int size)
     {
-        List<String> sentenceList = spiltSentence(document);
+    	return getTopSentenceList(document, size, default_sentence_separator);
+    }
+
+    /**
+     * 一句话调用接口
+     *
+     * @param document 目标文档
+     * @param size     需要的关键句的个数
+     * @param sentence_separator 句子分隔符，正则格式， 如：[。？?！!；;]
+     * @return 关键句列表
+     */
+    public static List<String> getTopSentenceList(String document, int size, String sentence_separator)
+    {
+        List<String> sentenceList = splitSentence(document, sentence_separator);
         List<List<String>> docs = convertSentenceListToDocument(sentenceList);
         TextRankSentence textRank = new TextRankSentence(docs);
         int[] topSentence = textRank.getTopSentence(size);
@@ -232,7 +260,20 @@ public class TextRankSentence
      */
     public static String getSummary(String document, int max_length)
     {
-        List<String> sentenceList = spiltSentence(document);
+    	return getSummary(document, max_length, default_sentence_separator);
+    }
+
+    /**
+     * 一句话调用接口
+     *
+     * @param document   目标文档
+     * @param max_length 需要摘要的长度
+     * @param sentence_separator 句子分隔符，正则格式， 如：[。？?！!；;]
+     * @return 摘要文本
+     */
+    public static String getSummary(String document, int max_length, String sentence_separator)
+    {
+        List<String> sentenceList = splitSentence(document, sentence_separator);
 
         int sentence_count = sentenceList.size();
         int document_length = document.length();

--- a/src/test/java/com/hankcs/test/other/TestExtractSummary.java
+++ b/src/test/java/com/hankcs/test/other/TestExtractSummary.java
@@ -1,0 +1,55 @@
+/**
+ * 
+ */
+package com.hankcs.test.other;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+
+import org.junit.Test;
+
+import com.hankcs.hanlp.HanLP;
+
+/**
+ * @author gonggawang
+ *
+ */
+public class TestExtractSummary 
+{
+	private static final String str = "7月21日，渤海海况恶劣，至少发生3起沉船事故，10余名船员危在旦夕。危急时刻，中国海油渤海油田再次行动起来，紧急调配救援力量救起10名遇险人员。"
+			+ "21日一早，一阵急促的铃声，在渤海石油管理局总值班室骤然响起。这是天津海上搜救中心打来的电话。正在值班的作业协调部主管邬礼凯心里“咯噔”一下——天津海上搜救中心称，"
+			+ "在“海洋石油932”平台西南方7海里处，一艘货轮遇险、处于倾覆边缘，4名船员命悬一线。时间就是生命！邬礼凯立即组织海上救援力量，立即驰奔事故发生地点。"
+			+ "“滨海264”船接到任务单后，仅一个小时便抵达事故现场。此时，货船已完全倾覆。“滨海264”立刻开展救援工作，仅25分钟便将4人全部救出。";
+	
+	private static final String separator = "[。?？!！]";
+	
+	@Test
+	public void testExctractSummay() 
+	{
+		List<String> oldSum = HanLP.extractSummary(str, 2);
+		List<String> newSum = HanLP.extractSummary(str, 2, separator);
+		System.out.println("exctractSummay old:" + oldSum);
+		System.out.println("exctractSummay new:" + newSum);
+		
+		assertTrue(oldSum.toString().length() < newSum.toString().length());
+		assertFalse(oldSum.toString().contains("，"));
+		assertTrue(newSum.toString().contains("，"));
+	}
+	
+	@Test
+	public void testGetSummary() 
+	{
+		
+		String oldSum = HanLP.getSummary(str, 100);
+		String newSum = HanLP.getSummary(str, 100, separator);
+		
+		System.out.println("getSummay old:" + oldSum);
+		System.out.println("getSummay new:" + newSum);
+		
+		assertFalse(oldSum.contains("，"));
+		assertTrue(newSum.contains("，"));
+	}
+	
+}


### PR DESCRIPTION
<!--
感谢你对开源事业的贡献！这是一份模板，方便记录你做出的功绩，谢谢！
-->

## 注意事项

* 这次修改没有引入第三方类库。
* 也没有修改JDK版本号
* 所有文本都是UTF-8编码
* 代码风格一致
* [ x] 我在此括号内输入x打钩，代表上述事项确认完毕。

## 解决了什么问题？带来了什么好处？
原来的文本摘要抽取方法无法指定句子之间的分割符，因为逗号是默认分割符之一，会造成抽取结果语义破碎。增加两个新的文本摘要抽取方法，在抽取文本摘要时指定句子分割符。原来的抽取方法仍然会采用默认的句子分割符。

<!-- 你的补丁解决了什么问题，给大家带来了什么好处？ -->

## 相关issue
无。
测试方法为：src/test/java/com/hankcs/test/other/TestExtractSummary.java
<!-- 如果跟已有issue相关的话，麻烦列一下 -->


