### PR TITLE
fix chinese numbers link with roman numbers

### DIFF
--- a/src/main/java/com/hankcs/hanlp/dictionary/other/CharType.java
+++ b/src/main/java/com/hankcs/hanlp/dictionary/other/CharType.java
@@ -61,6 +61,11 @@ public class CharType
     public static final byte CT_INDEX = CT_SINGLE + 5;
 
     /**
+     * 中文数字
+     */
+    public static final byte CT_CNUM = CT_SINGLE + 6;
+
+    /**
      * 其他
      */
     public static final byte CT_OTHER = CT_SINGLE + 12;

--- a/src/main/java/com/hankcs/hanlp/utility/TextUtility.java
+++ b/src/main/java/com/hankcs/hanlp/utility/TextUtility.java
@@ -41,6 +41,11 @@ public class TextUtility
     public static final int CT_INDEX = CT_SINGLE + 5;// HanYu Pinyin
 
     /**
+     * 中文数字
+     */
+    public static final int CT_CNUM = CT_SINGLE + 6;
+
+    /**
      * 其他
      */
     public static final int CT_OTHER = CT_SINGLE + 12;// Other
@@ -59,7 +64,8 @@ public class TextUtility
     {
         if (str != null && str.length() > 0)
         {
-            if ("零○〇一二两三四五六七八九十廿百千万亿壹贰叁肆伍陆柒捌玖拾佰仟".contains(str)) return CT_NUM;
+            if ("零○〇一二两三四五六七八九十廿百千万亿壹贰叁肆伍陆柒捌玖拾佰仟".contains(str)) return CT_CNUM;
+            System.out.println("lijian");
             byte[] b;
             try
             {


### PR DESCRIPTION
<!--
感谢你对开源事业的贡献！这是一份模板，方便记录你做出的功绩，谢谢！
-->

## 注意事项

* 这次修改没有引入第三方类库。
* 也没有修改JDK版本号
* 所有文本都是UTF-8编码
* 代码风格一致
* [x] 我在此括号内输入x打钩，代表上述事项确认完毕。

## 解决了什么问题？带来了什么好处？

<!-- 你的补丁解决了什么问题，给大家带来了什么好处？ -->

目前的版本对中文数字和罗马数字没有分开，例如：“赵四158开头的号码”会把“四158”分到一起。原因是构建词图的时候就没有切开，通过改词典并不能解决问题。

新版本新增CT_CNUM类型表示中文数字类，经测试，构建词图时，中文数字和罗马数字会切开，其他逻辑不变。“赵四158开头的号码”会把“赵四”，“156”单独分开。

## 相关issue

<!-- 如果跟已有issue相关的话，麻烦列一下 -->


