### PR TITLE
#623尚未修改完全的部分：确保中文数字的词性为m

### DIFF
--- a/src/main/java/com/hankcs/hanlp/seg/CharacterBasedGenerativeModelSegment.java
+++ b/src/main/java/com/hankcs/hanlp/seg/CharacterBasedGenerativeModelSegment.java
@@ -110,7 +110,7 @@ public abstract class CharacterBasedGenerativeModelSegment extends Segment
      */
     protected List<Vertex> toVertexList(List<Term> wordList, boolean appendStart)
     {
-        ArrayList<Vertex> vertexList = new ArrayList<Vertex>(wordList.size() + 1);
+        ArrayList<Vertex> vertexList = new ArrayList<Vertex>(wordList.size() + 2);
         if (appendStart) vertexList.add(Vertex.newB());
         for (Term word : wordList)
         {

--- a/src/main/java/com/hankcs/hanlp/seg/NShort/Path/AtomNode.java
+++ b/src/main/java/com/hankcs/hanlp/seg/NShort/Path/AtomNode.java
@@ -12,6 +12,7 @@
 package com.hankcs.hanlp.seg.NShort.Path;
 
 import com.hankcs.hanlp.corpus.tag.Nature;
+import com.hankcs.hanlp.dictionary.other.CharType;
 import com.hankcs.hanlp.dictionary.CoreDictionary;
 import com.hankcs.hanlp.seg.common.Vertex;
 import com.hankcs.hanlp.utility.Predefine;
@@ -46,29 +47,30 @@ public class AtomNode
         Nature nature = Nature.nz;
         switch (nPOS)
         {
-            case Predefine.CT_CHINESE:
+            case CharType.CT_CHINESE:
                 break;
-            case Predefine.CT_INDEX:
-            case Predefine.CT_NUM:
+            case CharType.CT_NUM:
+            case CharType.CT_INDEX:
+            case CharType.CT_CNUM:
                 nature = Nature.m;
-                sWord = "未##数";
+                sWord = Predefine.TAG_NUMBER;
                 break;
-            case Predefine.CT_DELIMITER:
+            case CharType.CT_DELIMITER:
                 nature = Nature.w;
                 break;
-            case Predefine.CT_LETTER:
+            case CharType.CT_LETTER:
                 nature = Nature.nx;
-                sWord = "未##串";
+                sWord = Predefine.TAG_CLUSTER;
                 break;
-            case Predefine.CT_SINGLE://12021-2129-3121
+            case CharType.CT_SINGLE://12021-2129-3121
                 if (Predefine.PATTERN_FLOAT_NUMBER.matcher(sWord).matches())//匹配浮点数
                 {
                     nature = Nature.m;
-                    sWord = "未##数";
+                    sWord = Predefine.TAG_NUMBER;
                 } else
                 {
                     nature = Nature.nx;
-                    sWord = "未##串";
+                    sWord = Predefine.TAG_CLUSTER;
                 }
                 break;
             default:
@@ -93,29 +95,30 @@ public class AtomNode
         int dValue = 1;
         switch (type)
         {
-            case Predefine.CT_CHINESE:
+            case CharType.CT_CHINESE:
                 break;
-            case Predefine.CT_INDEX:
-            case Predefine.CT_NUM:
+            case CharType.CT_NUM:
+            case CharType.CT_INDEX:
+            case CharType.CT_CNUM:
                 nature = Nature.m;
-                word = "未##数";
+                word = Predefine.TAG_NUMBER;
                 break;
-            case Predefine.CT_DELIMITER:
+            case CharType.CT_DELIMITER:
                 nature = Nature.w;
                 break;
-            case Predefine.CT_LETTER:
+            case CharType.CT_LETTER:
                 nature = Nature.nx;
-                word = "未##串";
+                word = Predefine.TAG_CLUSTER;
                 break;
-            case Predefine.CT_SINGLE://12021-2129-3121
+            case CharType.CT_SINGLE://12021-2129-3121
 //                if (Pattern.compile("^(-?\\d+)(\\.\\d+)?$").matcher(word).matches())//匹配浮点数
 //                {
 //                    nature = Nature.m;
-//                    word = "未##数";
+//                    word = Predefine.TAG_NUMBER;
 //                } else
 //                {
                     nature = Nature.nx;
-                    word = "未##串";
+                    word = Predefine.TAG_CLUSTER;
 //                }
                 break;
             default:

--- a/src/main/java/com/hankcs/hanlp/seg/Segment.java
+++ b/src/main/java/com/hankcs/hanlp/seg/Segment.java
@@ -143,7 +143,7 @@ public abstract class Segment
     protected static List<AtomNode> simpleAtomSegment(char[] charArray, int start, int end)
     {
         List<AtomNode> atomNodeList = new LinkedList<AtomNode>();
-        atomNodeList.add(new AtomNode(new String(charArray, start, end - start), Predefine.CT_LETTER));
+        atomNodeList.add(new AtomNode(new String(charArray, start, end - start), CharType.CT_LETTER));
         return atomNodeList;
     }
 
@@ -167,12 +167,15 @@ public abstract class Segment
             if (curType != preType)
             {
                 // 浮点数识别
-                if (charArray[offsetAtom] == '.' && preType == CharType.CT_NUM)
+                if ((charArray[offsetAtom] == '.' || charArray[offsetAtom] == '．') && preType == CharType.CT_NUM)
                 {
-                    while (++offsetAtom < end)
+                    if (offsetAtom+1 < end)
                     {
-                        curType = CharType.get(charArray[offsetAtom]);
-                        if (curType != CharType.CT_NUM) break;
+                        int nextType = CharType.get(charArray[offsetAtom+1]);
+                        if (nextType == CharType.CT_NUM) 
+                        {
+                            continue;
+                        }
                     }
                 }
                 atomNodeList.add(new AtomNode(new String(charArray, start, offsetAtom - start), preType));

--- a/src/main/java/com/hankcs/hanlp/seg/WordBasedGenerativeModelSegment.java
+++ b/src/main/java/com/hankcs/hanlp/seg/WordBasedGenerativeModelSegment.java
@@ -323,12 +323,12 @@ public abstract class WordBasedGenerativeModelSegment extends Segment
             c = charArray[i];
             charTypeArray[i] = CharType.get(c);
 
-            if (c == '.' && i < (charArray.length - 1) && CharType.get(charArray[i + 1]) == Predefine.CT_NUM)
-                charTypeArray[i] = Predefine.CT_NUM;
+            if (c == '.' && i < (charArray.length - 1) && CharType.get(charArray[i + 1]) == CharType.CT_NUM)
+                charTypeArray[i] = CharType.CT_NUM;
             else if (c == '.' && i < (charArray.length - 1) && charArray[i + 1] >= '0' && charArray[i + 1] <= '9')
-                charTypeArray[i] = Predefine.CT_SINGLE;
-            else if (charTypeArray[i] == Predefine.CT_LETTER)
-                charTypeArray[i] = Predefine.CT_SINGLE;
+                charTypeArray[i] = CharType.CT_SINGLE;
+            else if (charTypeArray[i] == CharType.CT_LETTER)
+                charTypeArray[i] = CharType.CT_SINGLE;
         }
 
         // 根据字符类型数组中的内容完成原子切割
@@ -336,8 +336,8 @@ public abstract class WordBasedGenerativeModelSegment extends Segment
         {
             nCurType = charTypeArray[pCur];
 
-            if (nCurType == Predefine.CT_CHINESE || nCurType == Predefine.CT_INDEX ||
-                    nCurType == Predefine.CT_DELIMITER || nCurType == Predefine.CT_OTHER)
+            if (nCurType == CharType.CT_CHINESE || nCurType == CharType.CT_INDEX ||
+                    nCurType == CharType.CT_DELIMITER || nCurType == CharType.CT_OTHER)
             {
                 String single = String.valueOf(charArray[pCur]);
                 if (single.length() != 0)
@@ -345,7 +345,7 @@ public abstract class WordBasedGenerativeModelSegment extends Segment
                 pCur++;
             }
             //如果是字符、数字或者后面跟随了数字的小数点“.”则一直取下去。
-            else if (pCur < charArray.length - 1 && ((nCurType == Predefine.CT_SINGLE) || nCurType == Predefine.CT_NUM))
+            else if (pCur < charArray.length - 1 && ((nCurType == CharType.CT_SINGLE) || nCurType == CharType.CT_NUM))
             {
                 sb.delete(0, sb.length());
                 sb.append(charArray[pCur]);

--- a/src/main/java/com/hankcs/hanlp/seg/common/Vertex.java
+++ b/src/main/java/com/hankcs/hanlp/seg/common/Vertex.java
@@ -88,7 +88,7 @@ public class Vertex
      */
     public Vertex(String word, String realWord, CoreDictionary.Attribute attribute)
     {
-        this(word, realWord, attribute, -attribute.totalFrequency);
+        this(word, realWord, attribute, attribute == null ? -1 : -attribute.totalFrequency);
     }
 
     public Vertex(String word, String realWord, CoreDictionary.Attribute attribute, int wordID)

--- a/src/main/java/com/hankcs/hanlp/seg/common/WordNet.java
+++ b/src/main/java/com/hankcs/hanlp/seg/common/WordNet.java
@@ -12,6 +12,7 @@
 package com.hankcs.hanlp.seg.common;
 
 import com.hankcs.hanlp.dictionary.CoreDictionary;
+import com.hankcs.hanlp.dictionary.other.CharType;
 import com.hankcs.hanlp.corpus.tag.Nature;
 import com.hankcs.hanlp.seg.NShort.Path.AtomNode;
 import com.hankcs.hanlp.utility.MathTools;
@@ -21,6 +22,7 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.ListIterator;
+
 import static com.hankcs.hanlp.utility.Predefine.logger;
 
 /**
@@ -275,21 +277,22 @@ public class WordNet
             int id = -1;
             switch (atomNode.nPOS)
             {
-                case Predefine.CT_CHINESE:
+                case CharType.CT_CHINESE:
                     break;
-                case Predefine.CT_INDEX:
-                case Predefine.CT_NUM:
+                case CharType.CT_NUM:
+                case CharType.CT_INDEX:
+                case CharType.CT_CNUM:
                     nature = Nature.m;
-                    sWord = "未##数";
+                    sWord = Predefine.TAG_NUMBER;
                     id = CoreDictionary.M_WORD_ID;
                     break;
-                case Predefine.CT_DELIMITER:
-                case Predefine.CT_OTHER:
+                case CharType.CT_DELIMITER:
+                case CharType.CT_OTHER:
                     nature = Nature.w;
                     break;
-                case Predefine.CT_SINGLE://12021-2129-3121
+                case CharType.CT_SINGLE://12021-2129-3121
                     nature = Nature.nx;
-                    sWord = "未##串";
+                    sWord = Predefine.TAG_CLUSTER;
                     id = CoreDictionary.X_WORD_ID;
                     break;
                 default:

--- a/src/main/java/com/hankcs/hanlp/utility/Predefine.java
+++ b/src/main/java/com/hankcs/hanlp/utility/Predefine.java
@@ -28,12 +28,19 @@ public class Predefine
     public final static double MIN_PROBABILITY = 1e-10;
     public final static int CT_SENTENCE_BEGIN = 1;        //Sentence begin
     public final static int CT_SENTENCE_END = 4;          //Sentence ending
+    /** @deprecated 使用CharType中的相应常量 */
     public final static int CT_SINGLE = 5;                //SINGLE byte
+    /** @deprecated 使用CharType中的相应常量 */
     public final static int CT_DELIMITER = CT_SINGLE + 1; //delimiter
+    /** @deprecated 使用CharType中的相应常量 */
     public final static int CT_CHINESE = CT_SINGLE + 2;   //Chinese Char
+    /** @deprecated 使用CharType中的相应常量 */
     public final static int CT_LETTER = CT_SINGLE + 3;    //HanYu Pinyin
+    /** @deprecated 使用CharType中的相应常量 */
     public final static int CT_NUM = CT_SINGLE + 4;       //HanYu Pinyin
+    /** @deprecated 使用CharType中的相应常量 */
     public final static int CT_INDEX = CT_SINGLE + 5;     //HanYu Pinyin
+    /** @deprecated  */
     public final static int CT_OTHER = CT_SINGLE + 12;    //Other
     /**
      * 浮点数正则
@@ -43,7 +50,7 @@ public class Predefine
     public static String POSTFIX_SINGLE =
         "坝邦堡城池村单岛道堤店洞渡队峰府冈港阁宫沟国海号河湖环集江礁角街井郡坑口矿里岭楼路门盟庙弄牌派坡铺旗桥区渠泉山省市水寺塔台滩坛堂厅亭屯湾屋溪峡县线乡巷洋窑营屿园苑院闸寨站镇州庄族陂庵町";
 
-    public final static String[] POSTFIX_MUTIPLE = {"半岛","草原","城市","大堤","大公国","大桥","地区",
+    public final static String[] POSTFIX_MUTIPLE = {"半岛","草原","城区","大堤","大公国","大桥","地区",
         "帝国","渡槽","港口","高速公路","高原","公路","公园","共和国","谷地","广场",
         "国道","海峡","胡同","机场","集镇","教区","街道","口岸","码头","煤矿",
         "牧场","农场","盆地","平原","丘陵","群岛","沙漠","沙洲","山脉","山丘",

--- a/src/test/java/com/hankcs/test/seg/TestSegment.java
+++ b/src/test/java/com/hankcs/test/seg/TestSegment.java
@@ -302,6 +302,7 @@ public class TestSegment extends TestCase
 
     public void testIssue22() throws Exception
     {
+        StandardTokenizer.SEGMENT.enableNumberQuantifierRecognize(false);
         CoreDictionary.Attribute attribute = CoreDictionary.get("年");
         System.out.println(attribute);
         List<Term> termList = StandardTokenizer.segment("三年");
@@ -442,6 +443,13 @@ public class TestSegment extends TestCase
         seg.enableAllNamedEntityRecognize(true);
         seg.enableNumberQuantifierRecognize(true);
         System.out.println(seg.seg("一分钟就累了"));
+    }
+    
+    public void testIssue623() throws Exception
+    {
+        StandardTokenizer.SEGMENT.enableCustomDictionary(false);
+        System.out.println(HanLP.segment("赵四158开头的号码"));
+        System.out.println(HanLP.segment("上周四18:00召开股东大会"));
     }
 
     public void testIssue633() throws Exception


### PR DESCRIPTION

## 注意事项

* 这次修改没有引入第三方类库。
* 也没有修改JDK版本号
* 所有文本都是UTF-8编码
* 代码风格一致
* [x] 我在此括号内输入x打钩，代表上述事项确认完毕。

## 解决了什么问题？带来了什么好处？

确保中文数字的词性为m
字符类型统一使用CharType类中的常量，但TextUtility中的保留以便剥离使用

## 相关issue

#623