### PR TITLE
自定义词典更新时自动删除缓存文件

### DIFF
--- a/src/main/java/com/hankcs/hanlp/dictionary/CustomDictionary.java
+++ b/src/main/java/com/hankcs/hanlp/dictionary/CustomDictionary.java
@@ -302,6 +302,10 @@ public class CustomDictionary
     {
         try
         {
+            if (isDicNeedUpdate(path))
+            {
+                return false;
+            }
             ByteArray byteArray = ByteArray.createByteArray(path + Predefine.BIN_EXT);
             if (byteArray == null) return false;
             int size = byteArray.nextInt();
@@ -336,6 +340,38 @@ public class CustomDictionary
             return false;
         }
         return true;
+    }
+
+    /**
+     * 获取本地词典更新状态
+     * @return true 表示本地词典比缓存文件新，需要删除缓存
+     */
+    private static boolean isDicNeedUpdate(String mainPath)
+    {
+        if (HanLP.Config.IOAdapter != null &&
+            !HanLP.Config.IOAdapter.getClass().getName().contains("com.hankcs.hanlp.corpus.io.FileIOAdapter"))
+        {
+            return false;
+        }
+        String binPath = mainPath + Predefine.BIN_EXT;
+        File binFile = new File(binPath);
+        if (!binFile.exists())
+        {
+            return true;
+        }
+        long lastModified = binFile.lastModified();
+        String path[] = HanLP.Config.CustomDictionaryPath;
+        for (String p : path)
+        {
+            File f = new File(p);
+            if (f.exists() && f.lastModified() > lastModified)
+            {
+                IOUtil.deleteFile(binPath); // 删掉缓存
+                logger.info("已清除自定义词典缓存文件！");
+                return true;
+            }
+        }
+        return false;
     }
 
     /**

--- a/src/test/java/com/hankcs/hanlp/HanLPTest.java
+++ b/src/test/java/com/hankcs/hanlp/HanLPTest.java
@@ -11,4 +11,9 @@ public class HanLPTest extends TestCase
         assertTrue(HanLP.newSegment("维特比") instanceof ViterbiSegment);
         assertTrue(HanLP.newSegment("感知机") instanceof PerceptronLexicalAnalyzer);
     }
+
+    public void testDicUpdate()
+    {
+        System.out.println(HanLP.segment("大数据是一个新词汇！"));
+    }
 }


### PR DESCRIPTION
## 注意事项

* 这次修改没有引入第三方类库。
* 也没有修改JDK版本号
* 所有文本都是UTF-8编码
* 代码风格一致
* [x] 我在此括号内输入x打钩，代表上述事项确认完毕。

## 解决了什么问题？带来了什么好处？
经常在 Issues 中看到因为没有删除缓存造成的自定义词典不生效的问题。

本更新使得用户在使用本地文件系统的情况下（`com.hankcs.hanlp.corpus.io.FileIOAdapter`），修改自定义词典后，缓存文件会自动删除，从而达到自定义词典及时生效的目的。

