### PR TITLE
在CRFNERecgonizer中添加自定义NERTags功能

### DIFF
--- a/src/main/java/com/hankcs/hanlp/model/crf/CRFNERecognizer.java
+++ b/src/main/java/com/hankcs/hanlp/model/crf/CRFNERecognizer.java
@@ -172,10 +172,5 @@ public class CRFNERecognizer extends CRFTagger implements NERecognizer
             "# Bigram\n" +
             "B";
     }
-
-    public static void main (String[] args) throws IOException{
-        String[] nerTags = {"nr","nt"};
-        CRFNERecognizer c = new CRFNERecognizer(null,nerTags);
-        CRFNERecognizer c2 = new CRFNERecognizer(null);
-    }
+    
 }

--- a/src/main/java/com/hankcs/hanlp/model/crf/CRFNERecognizer.java
+++ b/src/main/java/com/hankcs/hanlp/model/crf/CRFNERecognizer.java
@@ -46,11 +46,21 @@ public class CRFNERecognizer extends CRFTagger implements NERecognizer
 
     public CRFNERecognizer(String modelPath) throws IOException
     {
+        this(modelPath,null);
+    }
+
+    public CRFNERecognizer(String modelPath,String[] customeNERTags) throws IOException
+    {
         super(modelPath);
         if (model == null)
         {
             tagSet = new NERTagSet();
             addDefaultNERLabels();
+            if (customeNERTags != null) {
+                for (String nerTags : customeNERTags) {
+                    addNERLabels(nerTags);
+                }
+            }
         }
         else
         {
@@ -64,6 +74,11 @@ public class CRFNERecognizer extends CRFTagger implements NERecognizer
         tagSet.nerLabels.add("nr");
         tagSet.nerLabels.add("ns");
         tagSet.nerLabels.add("nt");
+    }
+
+    public void addNERLabels(String newNerTag)
+    {
+        tagSet.nerLabels.add(newNerTag);
     }
 
     @Override
@@ -156,5 +171,11 @@ public class CRFNERecognizer extends CRFTagger implements NERecognizer
             "\n" +
             "# Bigram\n" +
             "B";
+    }
+
+    public static void main (String[] args) throws IOException{
+        String[] nerTags = {"nr","nt"};
+        CRFNERecognizer c = new CRFNERecognizer(null,nerTags);
+        CRFNERecognizer c2 = new CRFNERecognizer(null);
     }
 }

--- a/src/main/java/com/hankcs/hanlp/model/crf/CRFNERecognizer.java
+++ b/src/main/java/com/hankcs/hanlp/model/crf/CRFNERecognizer.java
@@ -49,15 +49,15 @@ public class CRFNERecognizer extends CRFTagger implements NERecognizer
         this(modelPath,null);
     }
 
-    public CRFNERecognizer(String modelPath,String[] customeNERTags) throws IOException
+    public CRFNERecognizer(String modelPath,String[] customNERTags) throws IOException
     {
         super(modelPath);
         if (model == null)
         {
             tagSet = new NERTagSet();
             addDefaultNERLabels();
-            if (customeNERTags != null) {
-                for (String nerTags : customeNERTags) {
+            if (customNERTags != null) {
+                for (String nerTags : customNERTags) {
                     addNERLabels(nerTags);
                 }
             }
@@ -172,5 +172,5 @@ public class CRFNERecognizer extends CRFTagger implements NERecognizer
             "# Bigram\n" +
             "B";
     }
-    
+
 }


### PR DESCRIPTION
<!--
感谢你对开源事业的贡献！这是一份模板，方便记录你做出的功绩，谢谢！
-->

## 注意事项

* 这次修改没有引入第三方类库。
* 也没有修改JDK版本号
* 所有文本都是UTF-8编码
* 代码风格一致
* [x] 我在此括号内输入x打钩，代表上述事项确认完毕。

## 解决了什么问题？带来了什么好处？

在com.hankcs.hanlp.model.crf.CRFNERecognizer中, construct一个空模型的时候会自动添加三个默认label, nerTagSet作为一个private attribute, 并没有很好的支持自训练ner时添加新的nerTag的需求. 修改后, 在保留原有功能的情况下, 可以直接通过new CRFNERecognizer(null, customTagSet)


## 相关issue
暂无