### PR TITLE
Change method name 'convert' to 'createSynonymList'

### DIFF
--- a/src/main/java/com/hankcs/hanlp/dictionary/CoreSynonymDictionary.java
+++ b/src/main/java/com/hankcs/hanlp/dictionary/CoreSynonymDictionary.java
@@ -115,7 +115,7 @@ public class CoreSynonymDictionary
      * @param withUndefinedItem 是否保留词典中没有的词语
      * @return
      */
-    public static List<CommonSynonymDictionary.SynonymItem> convert(List<Term> sentence, boolean withUndefinedItem)
+    public static List<CommonSynonymDictionary.SynonymItem> createSynonymList(List<Term> sentence, boolean withUndefinedItem)
     {
         List<CommonSynonymDictionary.SynonymItem> synonymItemList = new ArrayList<CommonSynonymDictionary.SynonymItem>(sentence.size());
         for (Term term : sentence)


### PR DESCRIPTION
This class is used to represent  CoreSynonymDictionary.  This method named 'convert' is to create a synonym list. Thus, the method name 'createSynonymList' is more intuitive than 'convert'.