### PR TITLE
修复：加载自定义停用词文件无效

### DIFF
--- a/src/main/java/com/hankcs/hanlp/dictionary/stopword/CoreStopWordDictionary.java
+++ b/src/main/java/com/hankcs/hanlp/dictionary/stopword/CoreStopWordDictionary.java
@@ -57,15 +57,15 @@ public class CoreStopWordDictionary
         {
             try
             {
-                dictionary = new StopWordDictionary(HanLP.Config.CoreStopWordDictionaryPath);
-                DataOutputStream out = new DataOutputStream(new BufferedOutputStream(IOUtil.newOutputStream(HanLP.Config.CoreStopWordDictionaryPath + Predefine.BIN_EXT)));
+                dictionary = new StopWordDictionary(coreStopWordDictionaryPath);
+                DataOutputStream out = new DataOutputStream(new BufferedOutputStream(IOUtil.newOutputStream(coreStopWordDictionaryPath + Predefine.BIN_EXT)));
                 dictionary.save(out);
                 out.close();
             }
             catch (Exception e)
             {
-                logger.severe("载入停用词词典" + HanLP.Config.CoreStopWordDictionaryPath + "失败"  + TextUtility.exceptionToString(e));
-                throw new RuntimeException("载入停用词词典" + HanLP.Config.CoreStopWordDictionaryPath + "失败");
+                logger.severe("载入停用词词典" + coreStopWordDictionaryPath + "失败"  + TextUtility.exceptionToString(e));
+                throw new RuntimeException("载入停用词词典" + coreStopWordDictionaryPath + "失败");
             }
         }
         else


### PR DESCRIPTION
- 修复：加载自定义停用词文件无效

<!--
感谢你对开源事业的贡献！这是一份模板，方便记录你做出的功绩，谢谢！
-->

## 注意事项

* 这次修改没有引入第三方类库。
* 也没有修改JDK版本号
* 所有文本都是UTF-8编码
* 代码风格一致
* [ ] 我在此括号内输入x打钩，代表上述事项确认完毕。

## 解决了什么问题？带来了什么好处？

<!-- 你的补丁解决了什么问题，给大家带来了什么好处？ -->

## 相关issue

<!-- 如果跟已有issue相关的话，麻烦列一下 -->


