### PR TITLE
Nature is not concurrent safe. Change TreeMap to ConcurrentHashMap

### DIFF
--- a/src/main/java/com/hankcs/hanlp/corpus/tag/Nature.java
+++ b/src/main/java/com/hankcs/hanlp/corpus/tag/Nature.java
@@ -12,6 +12,7 @@
 package com.hankcs.hanlp.corpus.tag;
 
 import java.util.TreeMap;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * 词性
@@ -762,21 +763,24 @@ public class Nature
      */
     public static final Nature begin = new Nature("begin");
 
-    private static TreeMap<String, Integer> idMap;
+    private static ConcurrentHashMap<String, Integer> idMap;
     private static Nature[] values;
     private int ordinal;
     private final String name;
 
     private Nature(String name)
     {
-        if (idMap == null) idMap = new TreeMap<String, Integer>();
+        if (idMap == null) {
+            idMap = new ConcurrentHashMap<String, Integer>();
+        }
         assert !idMap.containsKey(name);
         this.name = name;
         ordinal = idMap.size();
         idMap.put(name, ordinal);
         Nature[] extended = new Nature[idMap.size()];
-        if (values != null)
+        if (values != null){
             System.arraycopy(values, 0, extended, 0, values.length);
+        }
         extended[ordinal] = this;
         values = extended;
     }


### PR DESCRIPTION
<!--
感谢你对开源事业的贡献！这是一份模板，方便记录你做出的功绩，谢谢！
-->

## 注意事项

* 这次修改没有引入第三方类库。
* 也没有修改JDK版本号
* 所有文本都是UTF-8编码
* 代码风格一致
* [x] 我在此括号内输入x打钩，代表上述事项确认完毕。

## 解决了什么问题？带来了什么好处？
Nature 这个类不是线程安全的，会在并发调用时产生服务Halt 的问题。
将Nature 中的 TreeMap 改成了 ConcurrentHashMap ，解决掉这个问题

<!-- 你的补丁解决了什么问题，给大家带来了什么好处？ -->

## 相关issue

<!-- 如果跟已有issue相关的话，麻烦列一下 -->


