### PR TITLE
fix errors for combineNER

### DIFF
--- a/src/main/java/com/hankcs/hanlp/model/perceptron/utility/Utility.java
+++ b/src/main/java/com/hankcs/hanlp/model/perceptron/utility/Utility.java
@@ -452,7 +452,7 @@ public class Utility
             }
             prePos = NERTagSet.posOf(nerArray[i]);
         }
-        if (nerArray.length - 1 - begin > 1)
+        if (nerArray.length - 1 - begin >= 1)
         {
             result.add(String.format("%d\t%d\t%s", begin, nerArray.length, prePos));
         }


### PR DESCRIPTION
fix errors when a compound word consists of two words and appears at the end of a sentence