### PR TITLE
bugfix: 修复 bintrie 树全分词时 提前跳出循环 bug

### DIFF
--- a/src/main/java/com/hankcs/hanlp/collection/trie/bintrie/BinTrie.java
+++ b/src/main/java/com/hankcs/hanlp/collection/trie/bintrie/BinTrie.java
@@ -608,6 +608,14 @@ public class BinTrie<V> extends BaseNode<V> implements ITrie<V>, Externalizable
                 {
                     processor.hit(begin, i + 1, value);
                 }
+
+                /*如果是最后一位，这里不能直接跳出循环， 要继续从下一个字符开始判断*/
+                if (i == length - 1)
+                {
+                    i = begin;
+                    ++begin;
+                    state = this;
+                }
             }
             else
             {
@@ -639,6 +647,14 @@ public class BinTrie<V> extends BaseNode<V> implements ITrie<V>, Externalizable
                 if (value != null)
                 {
                     processor.hit(begin, i + 1, value);
+                }
+
+                /*如果是最后一位，这里不能直接跳出循环， 要继续从下一个字符开始判断*/
+                if (i == length - 1)
+                {
+                    i = begin;
+                    ++begin;
+                    state = this;
                 }
             }
             else

--- a/src/test/java/com/hankcs/hanlp/collection/trie/bintrie/BinTrieParseTextTest.java
+++ b/src/test/java/com/hankcs/hanlp/collection/trie/bintrie/BinTrieParseTextTest.java
@@ -1,0 +1,56 @@
+package com.hankcs.hanlp.collection.trie.bintrie;
+
+import com.hankcs.hanlp.collection.AhoCorasick.AhoCorasickDoubleArrayTrie;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class BinTrieParseTextTest {
+
+
+    private final String[] words = new String[]{"溜", "儿", "溜儿", "一溜儿", "一溜"};
+    private BinTrie<Integer> trie;
+
+    @Before
+    public void setup() {
+        this.trie = new BinTrie<Integer>();
+        /*构建一个简单的词典， 从 core dict 文件中扣出的一部分*/
+        for (int i = 0; i < words.length; i++) {
+            this.trie.put(words[i], i);
+        }
+    }
+
+
+    @Test
+    public void testFullParse() {
+        assertFullParse("一溜儿");
+        assertFullParse("一溜儿    ");
+        assertFullParse("一溜儿 ");
+    }
+
+    private void assertFullParse(String text) {
+        Set<String> result = parseText(text);
+        /*确保每个词都被分出来了*/
+        for (String word : words) {
+            Assert.assertTrue(result.contains(word));
+        }
+    }
+
+
+    private Set<String> parseText(final String text) {
+        final Set<String> result = new HashSet<String>(words.length);
+        trie.parseText(text, new AhoCorasickDoubleArrayTrie.IHit<Integer>() {
+            @Override
+            public void hit(int begin, int end, Integer value) {
+                result.add(text.substring(begin, end));
+            }
+        });
+
+        return result;
+    }
+
+
+}


### PR DESCRIPTION
# bintrie 不能完全分词

## Description

使用 BinTrie 的代码某些场景不能进行有效的完全切词


下面是 bug 演示:

```java
import com.hankcs.hanlp.collection.AhoCorasick.AhoCorasickDoubleArrayTrie;
import org.junit.Before;
import org.junit.Test;

public class BinTrieParseTextTest {

    private BinTrie<Integer> trie;

    @Before
    public void setup() {
        this.trie = new BinTrie<Integer>();
        String[] words = new String[]{"溜", "儿", "溜儿", "一溜儿", "一溜"};
        /*构建一个简单的词典， 从 core dict 文件中扣出的一部分*/
        for (int i = 0; i < words.length; i++) {
            this.trie.put(words[i], i);
        }
    }


    @Test
    public void justForShowBugs() {
        showParseText("一溜儿");

        /*我们在 一溜儿后面随便+一个字符，这里我们加一个空格 会完全不同*/
        showParseText("一溜儿" + " ");

    }


    private void showParseText(final String text) {
        System.out.printf("========进行完全切词%s的演示======\n", text);
        this.trie.parseText(text, new AhoCorasickDoubleArrayTrie.IHit<Integer>() {
            @Override
            public void hit(int begin, int end, Integer value) {
                System.out.println(text.substring(begin, end));
            }
        });

        System.out.println("===========================");


    }
}

```

输出结果如下:

```
========进行完全切词一溜儿的演示======
一溜
一溜儿
===========================
========进行完全切词一溜儿 的演示======
一溜
一溜儿
溜
溜儿
儿
===========================
```


- 现象: 发现在 "一溜儿" 的情况分词不完全， 而把 BinTrie 改为 DoubleArrayTrie 则没有问题.
- 原因: debug 发现 bintrie 在分词命中了最后一个字符的时候 会提前跳出循环.


## How Has This Been Tested?

测试代码见 `com.hankcs.hanlp.collection.trie.bintrie.BinTrieParseTextTest.java`


