### PR TITLE
修复ViterbiSegment分词器中加载自定义词典时未替换DoubleArrayTrie导致分词不符合预期的问题

### DIFF
--- a/src/main/java/com/hankcs/hanlp/seg/Viterbi/ViterbiSegment.java
+++ b/src/main/java/com/hankcs/hanlp/seg/Viterbi/ViterbiSegment.java
@@ -211,7 +211,9 @@ public class ViterbiSegment extends WordBasedSegment
         File file = new File(mainPath);
         mainPath = file.getParent() + "/" + Math.abs(combinePath.toString().hashCode());
         mainPath = mainPath.replace("\\", "/");
-        DynamicCustomDictionary.loadMainDictionary(mainPath, path, dat, isCache, config.normalization);
+        if (DynamicCustomDictionary.loadMainDictionary(mainPath, path, dat, isCache, config.normalization)) {
+            this.customDictionary = new DynamicCustomDictionary(dat, null, null);
+        }
     }
 
     /**


### PR DESCRIPTION
<!--
Thank you for being interested in contributing to HanLP! You are awesome ✨.
⚠️Changes must be made on dev branch.
-->

# 修复ViterbiSegment分词器中加载自定义词典时未替换DoubleArrayTrie导致分词不符合预期的问题

## Description

ViterbiSegment加载自定义词典时未正确替换DoubleArrayTrie, 导致应该被切分出的词条未被切分

Fixes # (issue)

## Type of Change

Please check any relevant options and delete the rest.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## How Has This Been Tested?
com/hankcs/hanlp/seg/SegmentTest.java
```java
    public void testExtendViterbi() throws Exception
    {
        HanLP.Config.enableDebug(false);
        String path = System.getProperty("user.dir") + "/" + "data/dictionary/custom/CustomDictionary.txt;" +
            System.getProperty("user.dir") + "/" + "data/dictionary/custom/全国地名大全.txt";
        path = path.replace("\\", "/");
        String text = "一半天帕克斯曼是走不出丁字桥镇的";
        Segment segment = HanLP.newSegment().enableCustomDictionary(false);
        Segment seg = new ViterbiSegment(path);
        System.out.println("不启用字典的分词结果：" + segment.seg(text));
        System.out.println("默认分词结果：" + HanLP.segment(text));
        seg.enableCustomDictionaryForcing(true).enableCustomDictionary(true);
        List<Term> termList = seg.seg(text);
        System.out.println("自定义字典的分词结果：" + termList);
    }
```
![image](https://github.com/hankcs/HanLP/assets/27196120/73ae3c04-c3dc-4a87-ba0c-287c127b9829)


## Checklist

Check all items that apply.

- [x] ⚠️Changes **must** be made on `dev` branch instead of `master`
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
