### PR TITLE
fix:修复CWSEvaluator比较切分语句时的计算错误

### DIFF
--- a/src/main/java/com/hankcs/hanlp/seg/common/CWSEvaluator.java
+++ b/src/main/java/com/hankcs/hanlp/seg/common/CWSEvaluator.java
@@ -130,7 +130,7 @@ public class CWSEvaluator
                     }
                     A_cap_B_size++;
                     goldLen += wordArray[goldIndex].length();
-                    predLen += wordArray[goldIndex].length();
+                    predLen += predArray[predIndex].length();
                     goldIndex++;
                     predIndex++;
                 }


### PR DESCRIPTION
# fix:修复CWSEvaluator比较切分语句时的计算错误

## Description

CWSEvaluator类中的compare方法比较标准答案与分词结果时，循环逐一比较词语时，predLen的计算存在错误，增加了另一个数组的对应index位置词语的长度，而不是predArray本身数组的


## Type of Change

Please check any relevant options and delete the rest.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## How Has This Been Tested?

运行CWSEvaluatorTest的testGetPRF()方法debug即可

## Checklist

Check all items that apply.

- [x] ⚠️Changes **must** be made on `dev` branch instead of `master`
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
