### PR TITLE
Let PipeLine support copy()

### DIFF
--- a/hanlp/components/pipeline.py
+++ b/hanlp/components/pipeline.py
@@ -145,15 +145,21 @@ class Pipeline(Component, list):
         for component in self:
             doc = component(doc)
         return doc
-
+    
+    def copy(self):
+        return self.__copy__()
+    
+    def __copy__(self):
+        config = self.meta
+        return Pipeline.from_config(config)
+    
     @property
     def meta(self):
         return {
             'classpath': classpath_of(self),
             'hanlp_version': hanlp.version.__version__,
             'pipes': [pipe.config for pipe in self]
-        }
-
+        }    
     @meta.setter
     def meta(self, value):
         pass

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,0 +1,15 @@
+import unittest
+import hanlp
+
+
+class TestPipeLine(unittest.TestCase):
+    def test_copy(self):
+        pipe = hanlp.pipeline().append(hanlp.utils.rules.split_sentence)
+        copied_pipe = pipe.copy()
+        test_text = "今天天气真好。我要去散步。"
+        assert pipe is not copied_pipe
+        copied_pipe.append(lambda sent: "".join(sent))
+        assert pipe(test_text) != copied_pipe(test_text)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
<!--
Thank you for being interested in contributing to HanLP! You are awesome ✨.
⚠️Changes must be made on dev branch.
-->

# Let PipeLine support copy() 

## Description
now pipeline can be copied and add next-preprocessing step on needs withoud write duplicated append().

Fixes # (issue)

## Type of Change

Please check any relevant options and delete the rest.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

```
class TestPipeLine(unittest.TestCase):
    def test_copy(self):
        pipe = hanlp.pipeline().append(hanlp.utils.rules.split_sentence)
        copied_pipe = pipe.copy()
        test_text = "今天天气真好。我要去散步。"
        assert pipe is not copied_pipe
        copied_pipe.append(lambda sent: "".join(sent))
        assert pipe(test_text) != copied_pipe(test_text)
```

## Checklist

Check all items that apply.

- [x] ⚠️Changes **must** be made on `dev` branch instead of `master`
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
