### PR TITLE
fix(sec): upgrade com.fasterxml.jackson.core:jackson-databind to 

### DIFF
--- a/plugins/hanlp_restful_java/pom.xml
+++ b/plugins/hanlp_restful_java/pom.xml
@@ -99,7 +99,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.14.1</version>
+            <version>2.16.0</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in com.fasterxml.jackson.core:jackson-databind 2.14.1
- [CVE-2023-35116](https://www.oscs1024.com/hd/CVE-2023-35116)


### What did I do？
Upgrade com.fasterxml.jackson.core:jackson-databind from 2.14.1 to  for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How can we automate the detection of these types of issues?
By using the [GitHub Actions](https://github.com/murphysecurity/actions) configurations provided by murphysec, we can conduct automatic code security checks in our CI pipeline.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS